### PR TITLE
wip: support cables with multiple cable materials

### DIFF
--- a/ydr/cable.py
+++ b/ydr/cable.py
@@ -2,6 +2,7 @@ from bpy.types import (
     Object,
     Mesh,
 )
+from bmesh.types import BMesh
 from enum import Enum
 from typing import Optional
 import numpy as np
@@ -15,12 +16,18 @@ class CableAttr(str, Enum):
     DIFFUSE_FACTOR = ".cable.diffuse_factor"
     UM_SCALE = ".cable.um_scale"
     PHASE_OFFSET = ".cable.phase_offset"
+    # Blender materials are set on the mesh faces, which cable meshes don't have any of. We need an
+    # additional attribute on the vertices to support multiple materials on the same drawable model, since some
+    # vanilla models are like that (e.g. v_35_cables1.ydr)
+    MATERIAL_INDEX = ".cable.material_index"
 
     @property
     def type(self):
         match self:
             case CableAttr.PHASE_OFFSET:
                 return "FLOAT_VECTOR" # actually should be FLOAT2, but BMesh API doesn't expose those values
+            case CableAttr.MATERIAL_INDEX:
+                return "INT"
             case _:
                 return "FLOAT"
 
@@ -39,6 +46,8 @@ class CableAttr(str, Enum):
                 return 1.0
             case CableAttr.PHASE_OFFSET:
                 return Vector((0.0, 0.0, 0.0))
+            case CableAttr.MATERIAL_INDEX:
+                return 0
             case _:
                 assert False, f"Default value not set for cable attribute '{self}'"
 
@@ -53,6 +62,8 @@ class CableAttr(str, Enum):
                 return "Micromovements Scale"
             case CableAttr.PHASE_OFFSET:
                 return "Phase Offset"
+            case CableAttr.MATERIAL_INDEX:
+                return "Material Index"
             case _:
                 assert False, f"Label not set for cable attribute '{self}'"
 
@@ -67,6 +78,8 @@ class CableAttr(str, Enum):
                 return "Determines how much the cable moves: 0 = no micromovements"
             case CableAttr.PHASE_OFFSET:
                 return "Applies an offset to the simulation phase. Used to prevent movement of different cables from synchronizing"
+            case CableAttr.MATERIAL_INDEX:
+                return "Material slot index"
             case _:
                 assert False, f"Label not set for cloth attribute '{self}'"
 
@@ -100,6 +113,15 @@ def mesh_get_cable_attribute_values(mesh: Mesh, attr: CableAttr) -> np.ndarray:
     return values
 
 
+def bmesh_get_cable_attribute_values(mesh: BMesh, attr: CableAttr) -> np.ndarray:
+            #
+            # attr_layers = [(edit_mesh.verts.layers.float_vector if attr.type == "FLOAT_VECTOR" else edit_mesh.verts.layers.int if attr.type == "INT" else edit_mesh.verts.layers.float).get(attr, None) for attr in attrs]
+            # for v in edit_mesh.verts:
+            #     attr_values = [attr.default_value if attr_layers[i] is None else v[attr_layers[i]]
+            #                    for i, attr in enumerate(attrs)]
+    pass
+
+
 def is_cable_mesh_object(mesh_obj: Optional[Object]) -> bool:
     """Gets whether the object has a valid cable mesh."""
     if mesh_obj is None:
@@ -120,6 +142,6 @@ def is_cable_mesh(mesh: Optional[Mesh]) -> bool:
         len(mesh.polygons) == 0 and
         len(mesh.vertices) > 0 and
         len(mesh.edges) > 0 and
-        len(mesh.materials) == 1 and
-        mesh.materials[0].shader_properties.filename == CABLE_SHADER_NAME
+        len(mesh.materials) > 0 and
+        all(m.shader_properties.filename == CABLE_SHADER_NAME for m in mesh.materials)
     )

--- a/ydr/cable_mesh_builder.py
+++ b/ydr/cable_mesh_builder.py
@@ -17,6 +17,7 @@ class CablePoint:
     diffuse_factor: float = CableAttr.DIFFUSE_FACTOR.default_value
     um_scale: float = CableAttr.UM_SCALE.default_value
     phase_offset: (float, float) = CableAttr.PHASE_OFFSET.default_value
+    material_index: int = 0
 
     def __init__(self, point_index: int, position: Vector):
         self.point_index = point_index
@@ -44,6 +45,7 @@ class CableMeshBuilder:
 
         self.name = name
         self.materials = drawable_mats
+        self.has_multiple_materials = len(drawable_mats) > 1
 
     def build(self) -> Mesh:
         mesh = bpy.data.meshes.new(self.name)
@@ -53,6 +55,7 @@ class CableMeshBuilder:
         verts_diffuse_factor = []
         verts_um_scale = []
         verts_phase_offset = []
+        verts_material_index = []
         edges = []
 
         pieces = self._gather_pieces()
@@ -66,11 +69,13 @@ class CableMeshBuilder:
             verts_um_scale.extend(p.um_scale for p in piece.points)
             # NOTE: phase offset actually stored as FLOAT_VECTOR
             verts_phase_offset.extend((p.phase_offset[0], p.phase_offset[1], 0.0) for p in piece.points)
+            if self.has_multiple_materials:
+                verts_material_index.extend(p.material_index for p in piece.points)
             edges.extend(zip(range(first_idx, last_idx), range(first_idx + 1, last_idx + 1)))
 
         mesh.from_pydata(verts, edges, [])
 
-        self._create_mesh_materials(mesh)
+        self._create_mesh_materials(mesh, verts_material_index)
 
         mesh_add_cable_attribute(mesh, CableAttr.RADIUS)
         mesh_add_cable_attribute(mesh, CableAttr.DIFFUSE_FACTOR)
@@ -83,7 +88,12 @@ class CableMeshBuilder:
 
         return mesh
 
-    def _create_mesh_materials(self, mesh: bpy.types.Mesh):
+    def _create_mesh_materials(self, mesh: bpy.types.Mesh, verts_material_index: list[int]):
+        if not self.has_multiple_materials:
+            # Just a single material, 
+            mesh.materials.append(self.materials[0])
+            return
+
         drawable_mat_inds = np.unique(self.mat_inds)
         # Map drawable material indices to model material indices
         model_mat_inds = np.zeros(np.max(drawable_mat_inds) + 1, dtype=np.uint32)
@@ -95,6 +105,12 @@ class CableMeshBuilder:
         # NOTE: we just add the material and not assign it because Blender needs faces in the mesh to assign a
         #       material, but we don't have faces.
         #       On export, we just take the material from the materials list instead
+        mesh_add_cable_attribute(mesh, CableAttr.MATERIAL_INDEX)
+        mesh.attributes[CableAttr.MATERIAL_INDEX].data.foreach_set("value", model_mat_inds[verts_material_index])
+
+        # mesh.attributes.new("material_index", type="INT", domain="FACE")
+        # mesh.attributes["material_index"].data.foreach_set(
+        #     "value", model_mat_inds[self.mat_inds])
 
     def _gather_pieces(self) -> list[CablePiece]:
         pieces = []
@@ -113,17 +129,21 @@ class CableMeshBuilder:
 
         num_points = len(uniq_index)
 
+        material_index_per_vert = [0] * num_points
+
         # Find which point is the next one connected to each point. The game mesh connects two points with two
         # triangles, one going forward and the next one back. Here, we simplify the repesentation to a list of
         # points instead of triangles.
         next_map = [-1] * num_points
         prev_map = [-1] * num_points
-        for v0, v1, v2 in faces:
+        for face_index, (v0, v1, v2) in enumerate(faces):
             if v0 == v2: # forward tri
                 assert next_map[v0] == -1, "Point already connected!"
                 assert prev_map[v1] == -1, "Point already connected!"
                 next_map[v0] = v1
                 prev_map[v1] = v0
+                material_index_per_vert[v0] = self.mat_inds[face_index]
+                material_index_per_vert[v1] = self.mat_inds[face_index]
             else:
                 pass
 
@@ -162,6 +182,7 @@ class CableMeshBuilder:
                 point.diffuse_factor = a / 255
                 point.radius = abs(x)
                 point.um_scale = y / D if D != 0.0 else 0.0
+                point.material_index = material_index_per_vert[point.point_index]
 
             pieces.append(CablePiece(piece_points))
 

--- a/ydr/cable_overlays.py
+++ b/ydr/cable_overlays.py
@@ -50,7 +50,8 @@ class CableOverlaysDrawHandler:
         if (not scene.sz_ui_cable_radius_visualize and
             not scene.sz_ui_cable_diffuse_factor_visualize and
             not scene.sz_ui_cable_um_scale_visualize and
-            not scene.sz_ui_cable_phase_offset_visualize):
+            not scene.sz_ui_cable_phase_offset_visualize and
+                not scene.sz_ui_cable_material_index_visualize):
             return False
 
         obj = context.active_object
@@ -76,6 +77,8 @@ class CableOverlaysDrawHandler:
             attrs.append(CableAttr.UM_SCALE)
         if scene.sz_ui_cable_phase_offset_visualize:
             attrs.append(CableAttr.PHASE_OFFSET)
+        if scene.sz_ui_cable_material_index_visualize:
+            attrs.append(CableAttr.MATERIAL_INDEX)
         self.draw_attribute_values(obj, attrs)
 
     def draw_geometry(self):
@@ -109,9 +112,12 @@ class CableOverlaysDrawHandler:
             pos = location_3d_to_region_2d(region, rv3d, pos)
             if pos:
                 for i, attr_value in enumerate(attr_values):
-                    if attrs[i] == CableAttr.PHASE_OFFSET: # phase offset is a FLOAT_VECTOR, not FLOAT
+                    attr_type = attrs[i].type
+                    if attr_type == "FLOAT_VECTOR":
                         attr_str = f"{attr_value[0]:.2f}  {attr_value[1]:.2f}"
-                    else:
+                    elif attr_type == "INT":
+                        attr_str = f"{attr_value}"
+                    else:  # FLOAT
                         attr_str = f"{attr_value:.2f}"
                     w, h = blf.dimensions(font_id, attr_str)
                     attr_pos = pos - Vector((w * 0.5, h * i * 2 - (h * len(attr_values) / 2)))
@@ -120,7 +126,7 @@ class CableOverlaysDrawHandler:
 
         if cable_obj.mode == "EDIT":
             edit_mesh = bmesh.from_edit_mesh(mesh)
-            attr_layers = [(edit_mesh.verts.layers.float_vector if attr.type == "FLOAT_VECTOR" else edit_mesh.verts.layers.float).get(attr, None) for attr in attrs]
+            attr_layers = [(edit_mesh.verts.layers.float_vector if attr.type == "FLOAT_VECTOR" else edit_mesh.verts.layers.int if attr.type == "INT" else edit_mesh.verts.layers.float).get(attr, None) for attr in attrs]
             for v in edit_mesh.verts:
                 attr_values = [attr.default_value if attr_layers[i] is None else v[attr_layers[i]]
                                for i, attr in enumerate(attrs)]

--- a/ydr/cable_vertex_buffer_builder.py
+++ b/ydr/cable_vertex_buffer_builder.py
@@ -18,16 +18,18 @@ class CableVertexBufferBuilder:
         assert is_cable_mesh(mesh), "Non-cable mesh passed to CableVertexBufferBuilder"
         self.mesh = mesh
 
-    def build(self) -> NDArray:
+    def build(self) -> tuple[NDArray, NDArray]:
         verts_position = np.empty((len(self.mesh.vertices), 3), dtype=np.float32)
         self.mesh.attributes["position"].data.foreach_get("vector", verts_position.ravel())
         verts_radius = mesh_get_cable_attribute_values(self.mesh, CableAttr.RADIUS)
         verts_diffuse_factor = mesh_get_cable_attribute_values(self.mesh, CableAttr.DIFFUSE_FACTOR)
         verts_um_scale = mesh_get_cable_attribute_values(self.mesh, CableAttr.UM_SCALE)
         verts_phase_offset = mesh_get_cable_attribute_values(self.mesh, CableAttr.PHASE_OFFSET)
+        verts_material = mesh_get_cable_attribute_values(self.mesh, CableAttr.MATERIAL_INDEX)
 
         verts_phase_offset.clip(0.0, 1.0, out=verts_phase_offset)
         verts_diffuse_factor.clip(0.0, 1.0, out=verts_diffuse_factor)
+        verts_material.clip(0, len(self.mesh.materials) - 1, out=verts_material)
 
         pieces = edge_loops_from_edges(self.mesh)
 
@@ -48,6 +50,7 @@ class CableVertexBufferBuilder:
         struct_dtype = [VertexBuffer.VERT_ATTR_DTYPES[attr_name]
                         for attr_name in ("Position", "Normal", "Colour0", "TexCoord0")]
         output_vertex_arr = np.empty(num_output_verts, dtype=struct_dtype)
+        output_vertex_materials_arr = np.empty(num_output_verts, dtype=np.int32)
         v_pos = output_vertex_arr["Position"]
         v_tan = output_vertex_arr["Normal"]
         v_col = output_vertex_arr["Colour0"]
@@ -105,6 +108,7 @@ class CableVertexBufferBuilder:
                 v_col[out_vi][3] = int(verts_diffuse_factor[v0] * 255)
                 v_tex[out_vi][0] = -verts_radius[v0]  # negative
                 v_tex[out_vi][1] = distances[i0] * verts_um_scale[v0]
+                output_vertex_materials_arr[out_vi] = verts_material[v0]
 
                 v_pos[out_vi + 1] = verts_position[v1]
                 v_tan[out_vi + 1] = tangents[i1]
@@ -114,17 +118,22 @@ class CableVertexBufferBuilder:
                 v_col[out_vi + 1][3] = int(verts_diffuse_factor[v1] * 255)
                 v_tex[out_vi + 1][0] = -verts_radius[v1]  # negative
                 v_tex[out_vi + 1][1] = distances[i1] * verts_um_scale[v1]
+                output_vertex_materials_arr[out_vi + 1] = verts_material[v1]
 
                 #   same as first vertex but with positive radius
                 output_vertex_arr[out_vi + 2] = output_vertex_arr[out_vi]
                 v_tex[out_vi + 2][0] = verts_radius[v0]  # positive
+                output_vertex_materials_arr[out_vi + 2] = verts_material[v0]
 
                 # Second triangle (v0 +r -> v1 -r -> v1 +r)
                 output_vertex_arr[out_vi + 3] = output_vertex_arr[out_vi + 2]
                 output_vertex_arr[out_vi + 4] = output_vertex_arr[out_vi + 1]
                 output_vertex_arr[out_vi + 5] = output_vertex_arr[out_vi + 1]
                 v_tex[out_vi + 5][0] = verts_radius[v1]  # positive
+                output_vertex_materials_arr[out_vi + 3] = output_vertex_materials_arr[out_vi + 2]
+                output_vertex_materials_arr[out_vi + 4] = output_vertex_materials_arr[out_vi + 1]
+                output_vertex_materials_arr[out_vi + 5] = output_vertex_materials_arr[out_vi + 1]
 
                 out_vi += 6
 
-        return output_vertex_arr
+        return output_vertex_arr, output_vertex_materials_arr

--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -650,6 +650,10 @@ def register():
         name=CableAttr.PHASE_OFFSET.label, description=CableAttr.PHASE_OFFSET.description,
         size=2, min=0.0, max=1.0, default=CableAttr.PHASE_OFFSET.default_value[0:2]
     )
+    bpy.types.Scene.sz_ui_cable_material_index_visualize = bpy.props.BoolProperty(
+        name="Show Material Index", description="Display the cable material indices on the 3D Viewport",
+        default=False
+    )
 
 
 def unregister():
@@ -686,5 +690,6 @@ def unregister():
     del bpy.types.Scene.sz_ui_cable_um_scale
     del bpy.types.Scene.sz_ui_cable_phase_offset_visualize
     del bpy.types.Scene.sz_ui_cable_phase_offset
+    del bpy.types.Scene.sz_ui_cable_material_index_visualize
 
     bpy.app.handlers.load_post.remove(on_file_loaded)

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -794,3 +794,7 @@ class SOLLUMZ_PT_CABLE_TOOLS_PANEL(bpy.types.Panel):
         row = layout.row(align=True)
         op = row.operator(cable_ops.SOLLUMZ_OT_cable_randomize_phase_offset.bl_idname, text="Randomize")
 
+        row = layout.row(align=True)
+        row.label(text=CableAttr.MATERIAL_INDEX.label)
+        _visible_icon_prop(row, scene, "sz_ui_cable_material_index_visualize")
+

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -246,22 +246,28 @@ def create_geometries_xml(mesh_eval: bpy.types.Mesh, materials: list[bpy.types.M
             f"Could not create geometries for Drawable Model '{mesh_eval.original.name}': Mesh has no Sollumz materials!")
         return []
 
-    geometries: list[Geometry] = []
-
     if is_cable:
-        vert_buffer = CableVertexBufferBuilder(mesh_eval).build()
-        vert_buffer, ind_buffer = dedupe_and_get_indices(vert_buffer)
+        cable_total_vert_buffer, cable_vert_materials = CableVertexBufferBuilder(mesh_eval).build()
+        cable_geometries = []
+        for cable_material_index in range(len(mesh_eval.materials)):
+            cable_vert_buffer = cable_total_vert_buffer[cable_vert_materials == cable_material_index]
+            cable_vert_buffer, cable_ind_buffer = dedupe_and_get_indices(cable_vert_buffer)
 
-        geom_xml = Geometry()
-        geom_xml.bounding_box_max, geom_xml.bounding_box_min = get_geom_extents(vert_buffer["Position"])
-        geom_xml.shader_index = 0  # TODO: actually get cable material index
-        geom_xml.vertex_buffer.data = vert_buffer
-        geom_xml.index_buffer.data = ind_buffer
-        geometries.append(geom_xml)
-        return geometries
+            cable_material = mesh_eval.materials[cable_material_index].original
+            cable_material_index_in_drawable = materials.index(cable_material)
+
+            geom_xml = Geometry()
+            geom_xml.bounding_box_max, geom_xml.bounding_box_min = get_geom_extents(cable_vert_buffer["Position"])
+            geom_xml.shader_index = cable_material_index_in_drawable
+            geom_xml.vertex_buffer.data = cable_vert_buffer
+            geom_xml.index_buffer.data = cable_ind_buffer
+            cable_geometries.append(geom_xml)
+
+        return cable_geometries
 
     loop_inds_by_mat = get_loop_inds_by_material(mesh_eval, materials)
 
+    geometries: list[Geometry] = []
 
     bone_by_vgroup = get_bone_by_vgroup(
         vertex_groups, bones) if bones and vertex_groups else None

--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -119,29 +119,29 @@ def create_lod_meshes(model_data: ModelData, model_obj: bpy.types.Object, materi
     for lod_level, mesh_data in model_data.mesh_data_lods.items():
         mesh_name = f"{model_obj.name}_{SOLLUMZ_UI_NAMES[lod_level].lower().replace(' ', '_')}"
 
-        try:
-            if len(materials) == 1 and materials[0].shader_properties.filename == CABLE_SHADER_NAME:
-                mesh_builder = CableMeshBuilder(
-                    mesh_name,
-                    mesh_data.vert_arr,
-                    mesh_data.ind_arr,
-                    mesh_data.mat_inds,
-                    materials
-                )
-            else:
-                mesh_builder = MeshBuilder(
-                    mesh_name,
-                    mesh_data.vert_arr,
-                    mesh_data.ind_arr,
-                    mesh_data.mat_inds,
-                    materials
-                )
+        # try:
+        if all(m.shader_properties.filename == CABLE_SHADER_NAME for m in materials):
+            mesh_builder = CableMeshBuilder(
+                mesh_name,
+                mesh_data.vert_arr,
+                mesh_data.ind_arr,
+                mesh_data.mat_inds,
+                materials
+            )
+        else:
+            mesh_builder = MeshBuilder(
+                mesh_name,
+                mesh_data.vert_arr,
+                mesh_data.ind_arr,
+                mesh_data.mat_inds,
+                materials
+            )
 
-            lod_mesh = mesh_builder.build()
-        except:
-            logger.error(
-                f"Error occured during creation of mesh '{mesh_name}'! Is the mesh data valid?\n{traceback.format_exc()}")
-            continue
+        lod_mesh = mesh_builder.build()
+        # except:
+        #     logger.error(
+        #         f"Error occured during creation of mesh '{mesh_name}'! Is the mesh data valid?\n{traceback.format_exc()}")
+        #     continue
 
         lods.get_lod(lod_level).mesh = lod_mesh
         lods.active_lod_level = lod_level


### PR DESCRIPTION
There is like 25 vanilla models with multiple cable materials. Only a single material was supported before.

Uses a new custom attribute to set the materials as Blender only supports materials on faces. No tools to easily set the material yet, but import/export works.